### PR TITLE
deps(package): update pnpm to 10.18.2 and Node.js types to 24.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "type": "module",
   "keywords": [],
-  "packageManager": "pnpm@10.18.1",
+  "packageManager": "pnpm@10.18.2",
   "engines": {
     "node": ">=20",
     "pnpm:": ">=10"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ packages:
   '@types/conventional-commits-parser@5.0.1':
     resolution: {integrity: sha512-7uz5EHdzz2TqoMfV7ee61Egf5y6NkcO4FB/1iCCQnbeiI1F3xzv3vK5dBCXUCLQgGYS+mUeigK1iKQzvED+QnQ==}
 
-  '@types/node@24.7.0':
-    resolution: {integrity: sha512-IbKooQVqUBrlzWTi79E8Fw78l8k1RNtlDDNWsFZs7XonuQSJ8oNYfEeclhprUldXISRMLzBpILuKgPlIxm+/Yw==}
+  '@types/node@24.7.1':
+    resolution: {integrity: sha512-CmyhGZanP88uuC5GpWU9q+fI61j2SkhO3UGMUdfYRE6Bcy0ccyzn1Rqj9YAB/ZY4kOXmNf0ocah5GtphmLMP6Q==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -167,9 +167,9 @@ snapshots:
 
   '@types/conventional-commits-parser@5.0.1':
     dependencies:
-      '@types/node': 24.7.0
+      '@types/node': 24.7.1
 
-  '@types/node@24.7.0':
+  '@types/node@24.7.1':
     dependencies:
       undici-types: 7.14.0
 


### PR DESCRIPTION
## Overview

This PR updates package management and TypeScript type definitions to their latest patch versions, ensuring compatibility with the latest bug fixes and improvements.

The pnpm package manager is updated from 10.18.1 to 10.18.2, incorporating the latest stability improvements. Additionally, @types/node is upgraded from 24.7.0 to 24.7.1, providing updated TypeScript definitions for Node.js APIs.

## Changes

### Configuration

- `package.json`: Updated `packageManager` field from `pnpm@10.18.1` to `pnpm@10.18.2`
- `pnpm-lock.yaml`: Updated @types/node from 24.7.0 to 24.7.1 and synchronized dependency tree

### Files Changed

- Modified: package.json (1 line changed)
- Modified: pnpm-lock.yaml (8 lines changed)

**Total**: 2 files changed, 5 insertions(+), 5 deletions(-)

## Related Issues

No related issues.

## Breaking Changes

No breaking changes. This is a patch-level dependency update that maintains backward compatibility.

## Checklist

- [x] Changes follow project coding conventions
- [x] Dependencies are up to date
- [x] Lock file is synchronized with package.json
- [ ] Tests pass locally (N/A for dependency-only updates)
- [ ] Documentation updated (N/A for dependency-only updates)

## Additional Notes

This is a routine maintenance update focusing on keeping dependencies current with latest patch versions. No functionality changes are introduced.

### Dependency Update Details

**pnpm 10.18.2 changes**: Patch release with minor bug fixes and stability improvements
**@types/node 24.7.1 changes**: Updated TypeScript type definitions for Node.js 24.x APIs

No manual testing required as these are patch-level updates maintaining full backward compatibility.
