### PR TITLE
refactor(test): テストのパス参照を COMMANDS_ROOT に統一

### DIFF
--- a/configs/shellcheckrc
+++ b/configs/shellcheckrc
@@ -1,5 +1,5 @@
-// Copyright (c) 2026 Furukawa Atsushi <atsushifx@gmail.com># src: configs/shellcheckrc
-# @(#) : shellcheck configuration for aplys shell scripts
+# src: configs/shellcheckrc
+# @(#) : shellcheck configuration for shell scripts
 #
 # Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
 #
@@ -12,7 +12,9 @@ shell=bash
 # Minimum severity to report (style = all categories: error/warning/info/style)
 severity=style
 
-# SC2317 - unreachable code after return/exit
-#   shellspec test framework patterns; also present in .tools/shellspec/.shellcheckrc
-disable=SC2317
-
+# SC1090/SC1091 - dynamic/test helper source paths are resolved at runtime
+# SC2016 - ShellSpec hooks intentionally defer variable expansion
+# SC2034 - ShellSpec assertions and mock state inspect variables indirectly
+# SC2053 - test runner intentionally uses glob pattern matching
+# SC2317/SC2329 - ShellSpec/test mock functions are invoked indirectly
+disable=SC1090,SC1091,SC2016,SC2034,SC2053,SC2317,SC2329

--- a/plugins/idd-framework/commands/__tests__/__helpers/gh-mocks.lib.sh
+++ b/plugins/idd-framework/commands/__tests__/__helpers/gh-mocks.lib.sh
@@ -36,19 +36,19 @@
 # =============================================================================
 
 # Issue operations
-: "${mock_gh_fails:=0}"                    # 0=success, 1=fail
-: "${mock_issue_number:=42}"               # Default issue number for create
-: "${mock_new_issue_number:=42}"           # Alias for compatibility
+: "${mock_gh_fails:=0}"          # 0=success, 1=fail
+: "${mock_issue_number:=42}"     # Default issue number for create
+: "${mock_new_issue_number:=42}" # Alias for compatibility
 
 # Authentication
-: "${mock_gh_not_authenticated:=0}"        # 0=authenticated, 1=not authenticated
+: "${mock_gh_not_authenticated:=0}" # 0=authenticated, 1=not authenticated
 
 # PR operations
-: "${mock_pr_number:=1}"                   # Default PR number
-: "${mock_pr_fails:=0}"                    # PR operation failure flag
+: "${mock_pr_number:=1}" # Default PR number
+: "${mock_pr_fails:=0}"  # PR operation failure flag
 
 # Repository
-: "${mock_repo_name:=user/repo}"           # Default repository name
+: "${mock_repo_name:=user/repo}" # Default repository name
 
 # =============================================================================
 # Main gh Mock Function
@@ -65,22 +65,22 @@ setup_gh_mock() {
     local subcommand="$1"
 
     case "$subcommand" in
-      issue)
-        _gh_mock_issue "$@"
-        ;;
-      pr)
-        _gh_mock_pr "$@"
-        ;;
-      repo)
-        _gh_mock_repo "$@"
-        ;;
-      auth)
-        _gh_mock_auth "$@"
-        ;;
-      *)
-        echo "Mock gh: unknown subcommand '$subcommand'" >&2
-        return 1
-        ;;
+    issue)
+      _gh_mock_issue "$@"
+      ;;
+    pr)
+      _gh_mock_pr "$@"
+      ;;
+    repo)
+      _gh_mock_repo "$@"
+      ;;
+    auth)
+      _gh_mock_auth "$@"
+      ;;
+    *)
+      echo "Mock gh: unknown subcommand '$subcommand'" >&2
+      return 1
+      ;;
     esac
   }
 }
@@ -94,29 +94,29 @@ setup_gh_mock() {
 # @internal
 # @arg $@ All arguments passed to gh issue
 _gh_mock_issue() {
-  shift  # Remove 'issue'
+  shift # Remove 'issue'
   local action="$1"
 
   case "$action" in
-    create)
-      _gh_mock_issue_create "$@"
-      ;;
-    edit)
-      _gh_mock_issue_edit "$@"
-      ;;
-    list)
-      _gh_mock_issue_list "$@"
-      ;;
-    view)
-      _gh_mock_issue_view "$@"
-      ;;
-    close)
-      _gh_mock_issue_close "$@"
-      ;;
-    *)
-      echo "Mock gh issue: unknown action '$action'" >&2
-      return 1
-      ;;
+  create)
+    _gh_mock_issue_create "$@"
+    ;;
+  edit)
+    _gh_mock_issue_edit "$@"
+    ;;
+  list)
+    _gh_mock_issue_list "$@"
+    ;;
+  view)
+    _gh_mock_issue_view "$@"
+    ;;
+  close)
+    _gh_mock_issue_close "$@"
+    ;;
+  *)
+    echo "Mock gh issue: unknown action '$action'" >&2
+    return 1
+    ;;
   esac
 }
 
@@ -148,7 +148,7 @@ _gh_mock_issue_create() {
 # @exitcode 0 If mock_gh_fails=0
 # @exitcode 1 If mock_gh_fails=1
 _gh_mock_issue_edit() {
-  shift  # Remove 'edit'
+  shift # Remove 'edit'
   local issue_num="$1"
 
   if [[ "${mock_gh_fails:-0}" -eq 1 ]]; then
@@ -200,7 +200,7 @@ EOF
 # @exitcode 0 If mock_gh_fails=0
 # @exitcode 1 If mock_gh_fails=1
 _gh_mock_issue_view() {
-  shift  # Remove 'view'
+  shift # Remove 'view'
   local issue_num="$1"
 
   if [[ "${mock_gh_fails:-0}" -eq 1 ]]; then
@@ -227,7 +227,7 @@ EOF
 # @exitcode 0 If mock_gh_fails=0
 # @exitcode 1 If mock_gh_fails=1
 _gh_mock_issue_close() {
-  shift  # Remove 'close'
+  shift # Remove 'close'
   local issue_num="$1"
 
   if [[ "${mock_gh_fails:-0}" -eq 1 ]]; then
@@ -248,23 +248,23 @@ _gh_mock_issue_close() {
 # @internal
 # @arg $@ All arguments passed to gh pr
 _gh_mock_pr() {
-  shift  # Remove 'pr'
+  shift # Remove 'pr'
   local action="$1"
 
   case "$action" in
-    create)
-      _gh_mock_pr_create "$@"
-      ;;
-    list)
-      _gh_mock_pr_list "$@"
-      ;;
-    view)
-      _gh_mock_pr_view "$@"
-      ;;
-    *)
-      echo "Mock gh pr: unknown action '$action'" >&2
-      return 1
-      ;;
+  create)
+    _gh_mock_pr_create "$@"
+    ;;
+  list)
+    _gh_mock_pr_list "$@"
+    ;;
+  view)
+    _gh_mock_pr_view "$@"
+    ;;
+  *)
+    echo "Mock gh pr: unknown action '$action'" >&2
+    return 1
+    ;;
   esac
 }
 
@@ -310,7 +310,7 @@ EOF
 # @stdout JSON object with PR details
 # @exitcode 0 Always successful
 _gh_mock_pr_view() {
-  shift  # Remove 'view'
+  shift # Remove 'view'
   local pr_num="$1"
 
   cat <<EOF
@@ -333,17 +333,17 @@ EOF
 # @internal
 # @arg $@ All arguments passed to gh repo
 _gh_mock_repo() {
-  shift  # Remove 'repo'
+  shift # Remove 'repo'
   local action="$1"
 
   case "$action" in
-    view)
-      _gh_mock_repo_view "$@"
-      ;;
-    *)
-      echo "Mock gh repo: unknown action '$action'" >&2
-      return 1
-      ;;
+  view)
+    _gh_mock_repo_view "$@"
+    ;;
+  *)
+    echo "Mock gh repo: unknown action '$action'" >&2
+    return 1
+    ;;
   esac
 }
 
@@ -354,7 +354,7 @@ _gh_mock_repo() {
 # @stdout Repository name or JSON based on arguments
 # @exitcode 0 Always successful
 _gh_mock_repo_view() {
-  shift  # Remove 'view'
+  shift # Remove 'view'
 
   # Handle --json nameWithOwner -q .nameWithOwner
   if [[ "$*" =~ -q ]]; then
@@ -374,17 +374,17 @@ _gh_mock_repo_view() {
 # @internal
 # @arg $@ All arguments passed to gh auth
 _gh_mock_auth() {
-  shift  # Remove 'auth'
+  shift # Remove 'auth'
   local action="$1"
 
   case "$action" in
-    status)
-      _gh_mock_auth_status "$@"
-      ;;
-    *)
-      echo "Mock gh auth: unknown action '$action'" >&2
-      return 1
-      ;;
+  status)
+    _gh_mock_auth_status "$@"
+    ;;
+  *)
+    echo "Mock gh auth: unknown action '$action'" >&2
+    return 1
+    ;;
   esac
 }
 
@@ -433,22 +433,22 @@ set_gh_mock_failure() {
   local operation="$1"
 
   case "$operation" in
-    issue)
-      mock_gh_fails=1
-      ;;
-    pr)
-      mock_pr_fails=1
-      ;;
-    auth)
-      mock_gh_not_authenticated=1
-      ;;
-    all)
-      mock_gh_fails=1
-      mock_pr_fails=1
-      ;;
-    *)
-      echo "Unknown operation: $operation" >&2
-      return 1
-      ;;
+  issue)
+    mock_gh_fails=1
+    ;;
+  pr)
+    mock_pr_fails=1
+    ;;
+  auth)
+    mock_gh_not_authenticated=1
+    ;;
+  all)
+    mock_gh_fails=1
+    mock_pr_fails=1
+    ;;
+  *)
+    echo "Unknown operation: $operation" >&2
+    return 1
+    ;;
   esac
 }

--- a/plugins/idd-framework/commands/__tests__/__helpers/git-mocks.lib.sh
+++ b/plugins/idd-framework/commands/__tests__/__helpers/git-mocks.lib.sh
@@ -141,67 +141,67 @@ branch_exists() {
 mock_git() {
   git() {
     case "$1 $2" in
-      "branch --show-current")
-        # Return current branch
+    "branch --show-current")
+      # Return current branch
+      echo "$MOCK_CURRENT_BRANCH"
+      ;;
+
+    "branch --list")
+      # Check if branch exists in associative array
+      if branch_exists "$3"; then
+        echo "$3"
+      fi
+      ;;
+
+    "rev-parse --abbrev-ref")
+      # Support git rev-parse --abbrev-ref HEAD
+      if [ "$3" = "HEAD" ]; then
         echo "$MOCK_CURRENT_BRANCH"
-        ;;
+      fi
+      ;;
 
-      "branch --list")
-        # Check if branch exists in associative array
-        if branch_exists "$3"; then
-          echo "$3"
-        fi
-        ;;
-
-      "rev-parse --abbrev-ref")
-        # Support git rev-parse --abbrev-ref HEAD
-        if [ "$3" = "HEAD" ]; then
-          echo "$MOCK_CURRENT_BRANCH"
-        fi
-        ;;
-
-      "rev-parse --verify")
-        # Support git rev-parse --verify --quiet <branch>
-        # Check if branch exists in associative array
-        if branch_exists "$4"; then
-          echo "$4"
-          return 0
-        fi
-        return 1
-        ;;
-
-      "switch -c")
-         # Create new branch (only if it doesn't already exist)
-         if [ "${MOCK_BRANCHES[$3]}" = 1 ]; then
-           echo "fatal: a branch named '$3' already exists" >&2
-           return 1
-         fi
-         if [ "$MOCK_SWITCH_FAILS" = 1 ]; then
-           echo "fatal: unable to create branch" >&2
-           return 1
-         fi
-         echo "Switched to a new branch '$3'" >&2
-         return 0
-         ;;
-
-      "switch "*)
-         # Switch to existing branch (only if it exists)
-         if [ "${MOCK_BRANCHES[$2]}" != 1 ]; then
-           echo "error: pathspec '$2' did not match any file(s) known to git" >&2
-           return 1
-         fi
-         if [ "$MOCK_SWITCH_FAILS" = 1 ]; then
-           echo "fatal: unable to switch to branch '$2'" >&2
-           return 1
-         fi
-         echo "Switched to branch '$2'" >&2
-         return 0
-         ;;
-
-      *)
-        # Unsupported command - do nothing
+    "rev-parse --verify")
+      # Support git rev-parse --verify --quiet <branch>
+      # Check if branch exists in associative array
+      if branch_exists "$4"; then
+        echo "$4"
         return 0
-        ;;
+      fi
+      return 1
+      ;;
+
+    "switch -c")
+      # Create new branch (only if it doesn't already exist)
+      if [ "${MOCK_BRANCHES[$3]}" = 1 ]; then
+        echo "fatal: a branch named '$3' already exists" >&2
+        return 1
+      fi
+      if [ "$MOCK_SWITCH_FAILS" = 1 ]; then
+        echo "fatal: unable to create branch" >&2
+        return 1
+      fi
+      echo "Switched to a new branch '$3'" >&2
+      return 0
+      ;;
+
+    "switch "*)
+      # Switch to existing branch (only if it exists)
+      if [ "${MOCK_BRANCHES[$2]}" != 1 ]; then
+        echo "error: pathspec '$2' did not match any file(s) known to git" >&2
+        return 1
+      fi
+      if [ "$MOCK_SWITCH_FAILS" = 1 ]; then
+        echo "fatal: unable to switch to branch '$2'" >&2
+        return 1
+      fi
+      echo "Switched to branch '$2'" >&2
+      return 0
+      ;;
+
+    *)
+      # Unsupported command - do nothing
+      return 0
+      ;;
     esac
   }
 }

--- a/plugins/idd-framework/commands/__tests__/__helpers/idd-issue-branch-functions.lib.sh
+++ b/plugins/idd-framework/commands/__tests__/__helpers/idd-issue-branch-functions.lib.sh
@@ -52,8 +52,8 @@ setup_branch_functions() {
   # Extract bash code blocks from Script Library section using awk
   # Create temporary file to avoid stdin sourcing issues
   BRANCH_FUNCTIONS_TEMP_SCRIPT="${TMPDIR:-/tmp}/branch-functions-$$.sh"
-  sed -n '/^## スクリプトライブラリ/,/^## License$/p' "$branch_md" | \
-    awk '/^```bash$/ {flag=1; next} /^```$/ {flag=0; next} flag' > "$BRANCH_FUNCTIONS_TEMP_SCRIPT"
+  sed -n '/^## スクリプトライブラリ/,/^## License$/p' "$branch_md" |
+    awk '/^```bash$/ {flag=1; next} /^```$/ {flag=0; next} flag' >"$BRANCH_FUNCTIONS_TEMP_SCRIPT"
 
   # Source the extracted functions
   . "$BRANCH_FUNCTIONS_TEMP_SCRIPT"
@@ -100,7 +100,7 @@ create_test_last_session() {
       echo "LAST_BRANCH_NAME=\"$branch_name\""
     fi
     echo 'LAST_MODIFIED="2025-10-26T10:00:00+09:00"'
-  } > "$session_file"
+  } >"$session_file"
 }
 
 ##
@@ -126,7 +126,7 @@ create_test_branch_session() {
     echo "base_branch=\"$base_branch\""
     echo "issue_number=\"$issue_number\""
     echo 'LAST_MODIFIED="2025-10-26T10:00:00+09:00"'
-  } > "$session_file"
+  } >"$session_file"
 }
 
 # =============================================================================
@@ -148,13 +148,13 @@ mock_codex_mcp() {
   # Parse --prompt argument
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --prompt)
-        prompt="$2"
-        shift 2
-        ;;
-      *)
-        shift
-        ;;
+    --prompt)
+      prompt="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
     esac
   done
 
@@ -164,30 +164,30 @@ mock_codex_mcp() {
 
     # Simple domain inference based on keywords
     case "$title" in
-      *"/idd-issue"*|*"claude-commands"*)
-        echo "claude-commands"
-        return 0
-        ;;
-      *"xcp.sh"*|*"scripts"*)
-        echo "scripts"
-        return 0
-        ;;
-      *"README"*|*"docs"*)
-        echo "docs"
-        return 0
-        ;;
-      *"Add"*|*"Implement"*)
-        echo "feature"
-        return 0
-        ;;
-      *"Fix"*)
-        echo "bugfix"
-        return 0
-        ;;
-      *)
-        # Unknown case - simulate failure
-        return 1
-        ;;
+    *"/idd-issue"* | *"claude-commands"*)
+      echo "claude-commands"
+      return 0
+      ;;
+    *"xcp.sh"* | *"scripts"*)
+      echo "scripts"
+      return 0
+      ;;
+    *"README"* | *"docs"*)
+      echo "docs"
+      return 0
+      ;;
+    *"Add"* | *"Implement"*)
+      echo "feature"
+      return 0
+      ;;
+    *"Fix"*)
+      echo "bugfix"
+      return 0
+      ;;
+    *)
+      # Unknown case - simulate failure
+      return 1
+      ;;
     esac
   fi
 
@@ -232,22 +232,22 @@ detect_domain() {
 
   # Priority 3: Map issue_type to default domain (fallback)
   case "$issue_type" in
-    bug)
-      echo "bugfix"
-      ;;
-    feature)
-      echo "feature"
-      ;;
-    enhancement)
-      echo "enhancement"
-      ;;
-    task)
-      echo "task"
-      ;;
-    *)
-      # Fallback to issue_type as-is
-      echo "$issue_type"
-      ;;
+  bug)
+    echo "bugfix"
+    ;;
+  feature)
+    echo "feature"
+    ;;
+  enhancement)
+    echo "enhancement"
+    ;;
+  task)
+    echo "task"
+    ;;
+  *)
+    # Fallback to issue_type as-is
+    echo "$issue_type"
+    ;;
   esac
 
   # No title found - simulate failure

--- a/plugins/idd-framework/commands/__tests__/__helpers/idd-issue-branch-functions.lib.sh
+++ b/plugins/idd-framework/commands/__tests__/__helpers/idd-issue-branch-functions.lib.sh
@@ -74,6 +74,62 @@ cleanup_branch_functions() {
 }
 
 # =============================================================================
+# Test Session Fixtures
+# =============================================================================
+
+##
+# @brief Create a .last.session fixture for branch command tests
+# @param $1 Session file path
+# @param $2 Existing branch name (optional)
+##
+create_test_last_session() {
+  local session_file="$1"
+  local branch_name="${2:-}"
+
+  mkdir -p "$(dirname "$session_file")"
+  {
+    echo "# Last session"
+    echo 'LAST_ISSUE_FILE="issue-027-add-feature.md"'
+    echo 'LAST_ISSUE_NUMBER="027"'
+    echo 'LAST_COMMAND="new"'
+    echo 'LAST_ISSUE_TITLE="Add feature"'
+    echo 'LAST_ISSUE_TYPE="feature"'
+    echo 'LAST_COMMIT_TYPE="feat"'
+    echo 'LAST_BRANCH_TYPE="feat"'
+    if [ -n "$branch_name" ]; then
+      echo "LAST_BRANCH_NAME=\"$branch_name\""
+    fi
+    echo 'LAST_MODIFIED="2025-10-26T10:00:00+09:00"'
+  } > "$session_file"
+}
+
+##
+# @brief Create a .branch.session fixture for branch command tests
+# @param $1 Session file path
+# @param $2 Suggested branch
+# @param $3 Domain (optional)
+# @param $4 Base branch (optional)
+# @param $5 Issue number (optional)
+##
+create_test_branch_session() {
+  local session_file="$1"
+  local suggested_branch="$2"
+  local domain="${3:-test}"
+  local base_branch="${4:-main}"
+  local issue_number="${5:-27}"
+
+  mkdir -p "$(dirname "$session_file")"
+  {
+    echo "# Last session"
+    echo "suggested_branch=\"$suggested_branch\""
+    echo "domain=\"$domain\""
+    echo "base_branch=\"$base_branch\""
+    echo "issue_number=\"$issue_number\""
+    echo 'LAST_MODIFIED="2025-10-26T10:00:00+09:00"'
+  } > "$session_file"
+}
+
+# =============================================================================
 # Mock Functions
 # =============================================================================
 

--- a/plugins/idd-framework/commands/__tests__/__helpers/idd-issue-push-functions.lib.sh
+++ b/plugins/idd-framework/commands/__tests__/__helpers/idd-issue-push-functions.lib.sh
@@ -57,7 +57,7 @@ parse_issue_number_from_url() {
   local gh_output="$1"
 
   # Extract issue number from URL using sed (portable)
-  issue_number=$(echo "$gh_output" | \
+  issue_number=$(echo "$gh_output" |
     sed -n 's|.*https://github.com/[^/]*/[^/]*/issues/\([0-9]*\).*|\1|p' | head -n 1)
 
   if [[ -z "$issue_number" ]]; then
@@ -108,8 +108,8 @@ push_new_issue() {
   fi
 
   # Extract full URL using sed (portable)
-  issue_url=$(echo "$gh_output" | \
-    sed -n 's|.*\(https://github.com/[^/]*/[^/]*/issues/[0-9]*\).*|\1|p' | \
+  issue_url=$(echo "$gh_output" |
+    sed -n 's|.*\(https://github.com/[^/]*/[^/]*/issues/[0-9]*\).*|\1|p' |
     head -n 1)
 
   echo "✅ Issue created: #$issue_number"
@@ -263,16 +263,16 @@ setup_main_routine() {
 
     if [[ $prereq_exit_code -ne 0 ]]; then
       case $prereq_exit_code in
-        1)
-          echo "❌ Error: 'gh' command not found."
-          echo "💡 Please install GitHub CLI: https://cli.github.com/"
-          return 1
-          ;;
-        2)
-          echo "❌ Error: GitHub authentication required."
-          echo "💡 Run: gh auth login"
-          return 2
-          ;;
+      1)
+        echo "❌ Error: 'gh' command not found."
+        echo "💡 Please install GitHub CLI: https://cli.github.com/"
+        return 1
+        ;;
+      2)
+        echo "❌ Error: GitHub authentication required."
+        echo "💡 Run: gh auth login"
+        return 2
+        ;;
       esac
     fi
 

--- a/plugins/idd-framework/commands/__tests__/__helpers/idd-session-mocks.lib.sh
+++ b/plugins/idd-framework/commands/__tests__/__helpers/idd-session-mocks.lib.sh
@@ -35,8 +35,8 @@
 # =============================================================================
 
 # Session operations
-: "${mock_session_load_fails:=0}"          # 0=success, 1=fail
-: "${mock_session_save_fails:=0}"          # 0=success, 1=fail
+: "${mock_session_load_fails:=0}" # 0=success, 1=fail
+: "${mock_session_save_fails:=0}" # 0=success, 1=fail
 : "${mock_session_filename:=new-bug-login}"
 : "${mock_session_issue_number:=}"
 : "${mock_session_title:=Test Issue Title}"
@@ -45,11 +45,11 @@
 : "${mock_session_branch_type:=fix}"
 
 # File operations
-: "${mock_file_not_found:=0}"              # 0=file exists, 1=not found
-: "${mock_file_exists:=1}"                 # 1=file exists, 0=not found (for _validate_issue_file)
+: "${mock_file_not_found:=0}" # 0=file exists, 1=not found
+: "${mock_file_exists:=1}"    # 1=file exists, 0=not found (for _validate_issue_file)
 
 # Content extraction
-: "${mock_extract_fails:=0}"               # 0=success, 1=fail
+: "${mock_extract_fails:=0}" # 0=success, 1=fail
 : "${mock_extracted_title:=}"
 : "${mock_extracted_body:=Test issue body content with details.}"
 
@@ -73,7 +73,7 @@ setup_load_session_mock() {
     issue_number="${mock_session_issue_number:-}"
     command="push"
     TITLE="${mock_session_title:-Test Issue Title}"
-    title="${TITLE}"  # Set both uppercase and lowercase for compatibility
+    title="${TITLE}" # Set both uppercase and lowercase for compatibility
     ISSUE_TYPE="${mock_session_issue_type:-bug}"
     COMMIT_TYPE="${mock_session_commit_type:-fix}"
     BRANCH_TYPE="${mock_session_branch_type:-fix}"

--- a/plugins/idd-framework/commands/__tests__/__helpers/test-runner.lib.sh
+++ b/plugins/idd-framework/commands/__tests__/__helpers/test-runner.lib.sh
@@ -107,7 +107,7 @@ print_test_files() {
   while IFS= read -r file; do
     local rel_path="${file#"$base_dir"/}"
     echo "  - $rel_path"
-  done <<< "$test_files"
+  done <<<"$test_files"
   echo ""
 }
 
@@ -145,7 +145,7 @@ print_test_result() {
 # @exitcode 0 shellspec found
 # @exitcode 1 shellspec not found
 check_shellspec() {
-  if ! command -v shellspec &> /dev/null; then
+  if ! command -v shellspec &>/dev/null; then
     print_test_message "$TEST_RED" "❌ Error: shellspec not found"
     echo ""
     echo "Please install shellspec:"
@@ -196,7 +196,7 @@ find_tests_by_level() {
     fi
   done
 
-  test_files="${test_files%$'\n'}"  # Remove trailing newline
+  test_files="${test_files%$'\n'}" # Remove trailing newline
 
   if [[ -z "$test_files" ]]; then
     print_test_message "$TEST_YELLOW" "⚠️  Warning: No ${level} tests found in $test_dir"

--- a/plugins/idd-framework/commands/__tests__/e2e/idd-issue-push.e2e.spec.sh
+++ b/plugins/idd-framework/commands/__tests__/e2e/idd-issue-push.e2e.spec.sh
@@ -29,7 +29,8 @@
 #
 
 PROJECT_ROOT="${PROJECT_ROOT:-${SHELLSPEC_PROJECT_ROOT:-$(pwd)}}"
-HELPERS_DIR="$PROJECT_ROOT/.claude/commands/__tests__/__helpers"
+COMMANDS_ROOT="${COMMANDS_ROOT:-$PROJECT_ROOT/plugins/idd-framework/commands}"
+HELPERS_DIR="$COMMANDS_ROOT/__tests__/__helpers"
 . "$HELPERS_DIR/gh-mocks.lib.sh"
 . "$HELPERS_DIR/idd-session-mocks.lib.sh"
 . "$HELPERS_DIR/idd-issue-push-functions.lib.sh"

--- a/plugins/idd-framework/commands/__tests__/functional/filename-utils-slug.functional.spec.sh
+++ b/plugins/idd-framework/commands/__tests__/functional/filename-utils-slug.functional.spec.sh
@@ -31,7 +31,8 @@
 #
 
 PROJECT_ROOT="${PROJECT_ROOT:-${SHELLSPEC_PROJECT_ROOT:-$(pwd)}}"
-LIBS_DIR="$PROJECT_ROOT/.claude/commands/_libs"
+COMMANDS_ROOT="${COMMANDS_ROOT:-$PROJECT_ROOT/plugins/idd-framework/commands}"
+LIBS_DIR="$COMMANDS_ROOT/_libs"
 
 # Mock translator for fast testing without AI dependency
 mock_translator() {

--- a/plugins/idd-framework/commands/__tests__/functional/idd-issue-branch-commit.functional.spec.sh
+++ b/plugins/idd-framework/commands/__tests__/functional/idd-issue-branch-commit.functional.spec.sh
@@ -29,7 +29,8 @@
 #
 
 PROJECT_ROOT="${PROJECT_ROOT:-${SHELLSPEC_PROJECT_ROOT:-$(pwd)}}"
-HELPERS_DIR="$PROJECT_ROOT/.claude/commands/__tests__/__helpers"
+COMMANDS_ROOT="${COMMANDS_ROOT:-$PROJECT_ROOT/plugins/idd-framework/commands}"
+HELPERS_DIR="$COMMANDS_ROOT/__tests__/__helpers"
 . "$HELPERS_DIR/test-setup.lib.sh"
 . "$HELPERS_DIR/idd-issue-branch-functions.lib.sh"
 . "$HELPERS_DIR/git-mocks.lib.sh"

--- a/plugins/idd-framework/commands/__tests__/functional/idd-issue-branch-new.functional.spec.sh
+++ b/plugins/idd-framework/commands/__tests__/functional/idd-issue-branch-new.functional.spec.sh
@@ -22,7 +22,8 @@
 #
 
 PROJECT_ROOT="${PROJECT_ROOT:-${SHELLSPEC_PROJECT_ROOT:-$(pwd)}}"
-HELPERS_DIR="$PROJECT_ROOT/.claude/commands/__tests__/__helpers"
+COMMANDS_ROOT="${COMMANDS_ROOT:-$PROJECT_ROOT/plugins/idd-framework/commands}"
+HELPERS_DIR="$COMMANDS_ROOT/__tests__/__helpers"
 . "$HELPERS_DIR/idd-issue-branch-functions.lib.sh"
 
 # Setup branch functions from branch.md

--- a/plugins/idd-framework/commands/__tests__/integration/filename-utils-translation.integration.spec.sh
+++ b/plugins/idd-framework/commands/__tests__/integration/filename-utils-translation.integration.spec.sh
@@ -30,7 +30,8 @@
 #
 
 PROJECT_ROOT="${PROJECT_ROOT:-${SHELLSPEC_PROJECT_ROOT:-$(pwd)}}"
-LIBS_DIR="$PROJECT_ROOT/.claude/commands/_libs"
+COMMANDS_ROOT="${COMMANDS_ROOT:-$PROJECT_ROOT/plugins/idd-framework/commands}"
+LIBS_DIR="$COMMANDS_ROOT/_libs"
 
 # Source filename-utils.lib.sh for generate_slug and to_english_via_ai
 . "$LIBS_DIR/filename-utils.lib.sh"

--- a/plugins/idd-framework/commands/__tests__/integration/idd-issue-push.integration.spec.sh
+++ b/plugins/idd-framework/commands/__tests__/integration/idd-issue-push.integration.spec.sh
@@ -31,7 +31,8 @@
 
 # Load helper libraries
 PROJECT_ROOT="${PROJECT_ROOT:-$(pwd)}"
-HELPERS_DIR="$PROJECT_ROOT/.claude/commands/__tests__/__helpers"
+COMMANDS_ROOT="${COMMANDS_ROOT:-$PROJECT_ROOT/plugins/idd-framework/commands}"
+HELPERS_DIR="$COMMANDS_ROOT/__tests__/__helpers"
 . "$HELPERS_DIR/gh-mocks.lib.sh"
 . "$HELPERS_DIR/idd-session-mocks.lib.sh"
 . "$HELPERS_DIR/idd-issue-push-functions.lib.sh"

--- a/plugins/idd-framework/commands/__tests__/run-tests.sh
+++ b/plugins/idd-framework/commands/__tests__/run-tests.sh
@@ -72,7 +72,7 @@ fi
 # @stdout Help message
 # @exitcode 0 Always successful
 show_help() {
-  cat << 'EOF'
+  cat <<'EOF'
 Usage: run-tests.sh <subcommand> [test_file]
 
 Unified test runner for shellspec tests across all test levels.
@@ -235,16 +235,16 @@ main() {
 
   # Route to appropriate handler
   case "$subcommand" in
-    all)
-      run_all_levels
-      ;;
-    unit|functional|integration|e2e)
-      run_single_level "$subcommand" "$@"
-      ;;
-    *)
-      print_test_message "$TEST_RED" "❌ Error: Unexpected subcommand '$subcommand'"
-      exit 2
-      ;;
+  all)
+    run_all_levels
+    ;;
+  unit | functional | integration | e2e)
+    run_single_level "$subcommand" "$@"
+    ;;
+  *)
+    print_test_message "$TEST_RED" "❌ Error: Unexpected subcommand '$subcommand'"
+    exit 2
+    ;;
   esac
 }
 

--- a/plugins/idd-framework/commands/__tests__/unit/idd-issue-branch-base.unit.spec.sh
+++ b/plugins/idd-framework/commands/__tests__/unit/idd-issue-branch-base.unit.spec.sh
@@ -28,7 +28,8 @@
 #
 
 PROJECT_ROOT="${PROJECT_ROOT:-${SHELLSPEC_PROJECT_ROOT:-$(pwd)}}"
-HELPERS_DIR="$PROJECT_ROOT/.claude/commands/__tests__/__helpers"
+COMMANDS_ROOT="${COMMANDS_ROOT:-$PROJECT_ROOT/plugins/idd-framework/commands}"
+HELPERS_DIR="$COMMANDS_ROOT/__tests__/__helpers"
 . "$HELPERS_DIR/idd-issue-branch-functions.lib.sh"
 . "$HELPERS_DIR/git-mocks.lib.sh"
 

--- a/plugins/idd-framework/commands/__tests__/unit/idd-issue-branch-create.unit.spec.sh
+++ b/plugins/idd-framework/commands/__tests__/unit/idd-issue-branch-create.unit.spec.sh
@@ -33,7 +33,8 @@
 #
 
 PROJECT_ROOT="${PROJECT_ROOT:-${SHELLSPEC_PROJECT_ROOT:-$(pwd)}}"
-HELPERS_DIR="$PROJECT_ROOT/.claude/commands/__tests__/__helpers"
+COMMANDS_ROOT="${COMMANDS_ROOT:-$PROJECT_ROOT/plugins/idd-framework/commands}"
+HELPERS_DIR="$COMMANDS_ROOT/__tests__/__helpers"
 
 # Load helper libraries
 . "$HELPERS_DIR/idd-issue-branch-functions.lib.sh"

--- a/plugins/idd-framework/commands/__tests__/unit/idd-issue-branch-functions.unit.spec.sh
+++ b/plugins/idd-framework/commands/__tests__/unit/idd-issue-branch-functions.unit.spec.sh
@@ -29,7 +29,8 @@
 #
 
 PROJECT_ROOT="${PROJECT_ROOT:-${SHELLSPEC_PROJECT_ROOT:-$(pwd)}}"
-HELPERS_DIR="$PROJECT_ROOT/.claude/commands/__tests__/__helpers"
+COMMANDS_ROOT="${COMMANDS_ROOT:-$PROJECT_ROOT/plugins/idd-framework/commands}"
+HELPERS_DIR="$COMMANDS_ROOT/__tests__/__helpers"
 . "$HELPERS_DIR/idd-issue-branch-functions.lib.sh"
 
 # Setup branch functions from branch.md
@@ -222,7 +223,7 @@ Describe 'detect_domain() - T3 priority-based coordinator'
 
   Describe 'Given: generate_branch_name function'
     # Source filename-utils.lib.sh for generate_slug dependency
-    LIBS_DIR="$SHELLSPEC_PROJECT_ROOT/.claude/commands/_libs"
+    LIBS_DIR="$COMMANDS_ROOT/_libs"
     Include "$LIBS_DIR/filename-utils.lib.sh"
 
     Context 'When: generating basic branch name'

--- a/plugins/idd-framework/commands/__tests__/unit/idd-issue-branch-git-state.unit.spec.sh
+++ b/plugins/idd-framework/commands/__tests__/unit/idd-issue-branch-git-state.unit.spec.sh
@@ -28,7 +28,8 @@
 #
 
 PROJECT_ROOT="${PROJECT_ROOT:-${SHELLSPEC_PROJECT_ROOT:-$(pwd)}}"
-HELPERS_DIR="$PROJECT_ROOT/.claude/commands/__tests__/__helpers"
+COMMANDS_ROOT="${COMMANDS_ROOT:-$PROJECT_ROOT/plugins/idd-framework/commands}"
+HELPERS_DIR="$COMMANDS_ROOT/__tests__/__helpers"
 . "$HELPERS_DIR/idd-issue-branch-functions.lib.sh"
 
 # Setup branch functions from branch.md

--- a/plugins/idd-framework/commands/__tests__/unit/idd-issue-branch-help.unit.spec.sh
+++ b/plugins/idd-framework/commands/__tests__/unit/idd-issue-branch-help.unit.spec.sh
@@ -30,7 +30,8 @@
 #
 
 PROJECT_ROOT="${PROJECT_ROOT:-${SHELLSPEC_PROJECT_ROOT:-$(pwd)}}"
-HELPERS_DIR="$PROJECT_ROOT/.claude/commands/__tests__/__helpers"
+COMMANDS_ROOT="${COMMANDS_ROOT:-$PROJECT_ROOT/plugins/idd-framework/commands}"
+HELPERS_DIR="$COMMANDS_ROOT/__tests__/__helpers"
 . "$HELPERS_DIR/idd-issue-branch-functions.lib.sh"
 
 # Setup branch functions from branch.md

--- a/plugins/idd-framework/commands/__tests__/unit/idd-issue-branch-parse.unit.spec.sh
+++ b/plugins/idd-framework/commands/__tests__/unit/idd-issue-branch-parse.unit.spec.sh
@@ -29,7 +29,8 @@
 #
 
 PROJECT_ROOT="${PROJECT_ROOT:-${SHELLSPEC_PROJECT_ROOT:-$(pwd)}}"
-HELPERS_DIR="$PROJECT_ROOT/.claude/commands/__tests__/__helpers"
+COMMANDS_ROOT="${COMMANDS_ROOT:-$PROJECT_ROOT/plugins/idd-framework/commands}"
+HELPERS_DIR="$COMMANDS_ROOT/__tests__/__helpers"
 . "$HELPERS_DIR/idd-issue-branch-functions.lib.sh"
 
 # Setup branch functions from branch.md

--- a/plugins/idd-framework/commands/__tests__/unit/idd-issue-branch-session.unit.spec.sh
+++ b/plugins/idd-framework/commands/__tests__/unit/idd-issue-branch-session.unit.spec.sh
@@ -27,7 +27,8 @@
 #
 
 PROJECT_ROOT="${PROJECT_ROOT:-${SHELLSPEC_PROJECT_ROOT:-$(pwd)}}"
-HELPERS_DIR="$PROJECT_ROOT/.claude/commands/__tests__/__helpers"
+COMMANDS_ROOT="${COMMANDS_ROOT:-$PROJECT_ROOT/plugins/idd-framework/commands}"
+HELPERS_DIR="$COMMANDS_ROOT/__tests__/__helpers"
 . "$HELPERS_DIR/test-setup.lib.sh"
 . "$HELPERS_DIR/idd-issue-branch-functions.lib.sh"
 

--- a/plugins/idd-framework/commands/__tests__/unit/io-utils.unit.spec.sh
+++ b/plugins/idd-framework/commands/__tests__/unit/io-utils.unit.spec.sh
@@ -4,10 +4,11 @@
 # @(#) io-utils.lib.sh unit tests
 
 PROJECT_ROOT="${PROJECT_ROOT:-${SHELLSPEC_PROJECT_ROOT:-$(pwd)}}"
+COMMANDS_ROOT="${COMMANDS_ROOT:-$PROJECT_ROOT/plugins/idd-framework/commands}"
 
 # テスト対象のライブラリを読み込み
 # shellcheck disable=SC1091
-. "$PROJECT_ROOT/.claude/commands/_libs/io-utils.lib.sh"
+. "$COMMANDS_ROOT/_libs/io-utils.lib.sh"
 
 Describe 'io-utils.lib.sh'
   Describe 'error_print() function'

--- a/plugins/idd-framework/commands/_libs/filename-utils.lib.sh
+++ b/plugins/idd-framework/commands/_libs/filename-utils.lib.sh
@@ -89,10 +89,10 @@ generate_slug() {
 
   # Convert to lowercase, replace spaces and special chars with hyphens
   local slug
-  slug=$(printf '%s' "$text" | \
-    tr '[:upper:]' '[:lower:]' | \
-    sed 's/[^a-z0-9]/-/g' | \
-    sed 's/--*/-/g' | \
+  slug=$(printf '%s' "$text" |
+    tr '[:upper:]' '[:lower:]' |
+    sed 's/[^a-z0-9]/-/g' |
+    sed 's/--*/-/g' |
     sed 's/^-//; s/-$//')
 
   # Truncate to max length
@@ -100,7 +100,7 @@ generate_slug() {
 
   # Remove trailing incomplete word if truncated (cut at last hyphen)
   if [ ${#slug} -eq "$max_length" ]; then
-    slug="${slug%-*}"  # Remove everything after last hyphen for complete words only
+    slug="${slug%-*}" # Remove everything after last hyphen for complete words only
   fi
 
   echo "$slug"

--- a/plugins/idd-framework/commands/_libs/idd-file-ops.lib.sh
+++ b/plugins/idd-framework/commands/_libs/idd-file-ops.lib.sh
@@ -113,6 +113,6 @@ get_file_timestamp() {
   fi
 
   # クロスプラットフォーム対応
-  stat -c %y "$file_path" 2>/dev/null | cut -d' ' -f1,2 | cut -d: -f1,2 || \
+  stat -c %y "$file_path" 2>/dev/null | cut -d' ' -f1,2 | cut -d: -f1,2 ||
     date -r "$file_path" '+%Y-%m-%d %H:%M' 2>/dev/null
 }

--- a/plugins/idd-framework/commands/_libs/idd-session.lib.sh
+++ b/plugins/idd-framework/commands/_libs/idd-session.lib.sh
@@ -188,7 +188,7 @@ _save_session() {
     else
       echo "LAST_MODIFIED=\"$(date -Iseconds 2>/dev/null || date +%Y-%m-%dT%H:%M:%S)\""
     fi
-  } > "$session_file"
+  } >"$session_file"
 }
 
 ##
@@ -243,7 +243,7 @@ _save_last_file() {
     return 1
   fi
 
-  echo "$filename" > "$dir/.last_draft"
+  echo "$filename" >"$dir/.last_draft"
 }
 
 ##

--- a/plugins/idd-framework/commands/_libs/io-utils.lib.sh
+++ b/plugins/idd-framework/commands/_libs/io-utils.lib.sh
@@ -71,8 +71,8 @@ is_non_ascii() {
   non_ascii_chars=$(printf '%s' "$text" | LC_ALL=C sed 's/[\x00-\x7F]//g')
 
   if [ -n "$non_ascii_chars" ]; then
-    return 0  # non-ASCII found
+    return 0 # non-ASCII found
   fi
 
-  return 1  # pure ASCII
+  return 1 # pure ASCII
 }

--- a/runners/run-shellspec.sh
+++ b/runners/run-shellspec.sh
@@ -17,6 +17,7 @@ set -euo pipefail
 SHELLSPEC="${SHELLSPEC:-${PROJECT_ROOT}/.tools/shellspec/shellspec}"
 
 readonly TEST_TYPES=("all" "unit" "functional" "integration" "system" "e2e")
+readonly SPEC_DIR_BASE="__tests__"
 
 SKIP_INTEGRATION_TESTS="${SKIP_INTEGRATION_TESTS:-1}"
 SPEC_SEARCH_ROOT="${SPEC_SEARCH_ROOT:-${PROJECT_ROOT}}"
@@ -93,9 +94,9 @@ get_spec_files() {
 
   local type_filter
   if [[ "$test_type" == "all" ]]; then
-    type_filter="tests"
+    type_filter="$SPEC_DIR_BASE"
   else
-    type_filter="tests/${test_type}"
+    type_filter="${SPEC_DIR_BASE}/${test_type}"
   fi
 
   local -a spec_files

--- a/scripts/__tests__/unit/xcp.spec.sh
+++ b/scripts/__tests__/unit/xcp.spec.sh
@@ -187,7 +187,7 @@ Describe 'xcp.sh - Core Functions Unit Tests'
         The output should include "Backed up:"
         # Verify backup file was created (original dest_file was moved)
         The path "$dest_file" should not exist
-        backup_count=$(ls -1 "${dest_file}.bak."* 2>/dev/null | wc -l)
+        backup_count=$(find "$(dirname "$dest_file")" -maxdepth 1 -name "$(basename "$dest_file").bak.*" -type f | wc -l)
         The variable backup_count should equal 1
 
         # Cleanup

--- a/scripts/setup-idd.sh
+++ b/scripts/setup-idd.sh
@@ -47,7 +47,7 @@ cd "$REPO_ROOT" || exit 1
 
 # 1. Check jq installation
 echo "🔍 Checking jq installation..."
-if ! command -v jq &> /dev/null; then
+if ! command -v jq &>/dev/null; then
   echo "❌ jq not found. Please install jq."
   echo ""
   echo "Installation instructions:"

--- a/scripts/xcp.sh
+++ b/scripts/xcp.sh
@@ -524,31 +524,31 @@ assess_copy_preconditions() {
   fi
 
   case $OPERATION_MODE in
-    "$MODE_SKIP")
-      log_info "Skipped (exists): $dest_file"
-      return 1
-      ;;
-    "$MODE_OVERWRITE")
-      log_verbose "Overwriting: $dest_file"
+  "$MODE_SKIP")
+    log_info "Skipped (exists): $dest_file"
+    return 1
+    ;;
+  "$MODE_OVERWRITE")
+    log_verbose "Overwriting: $dest_file"
+    return 0
+    ;;
+  "$MODE_UPDATE")
+    if is_newer "$src" "$dest_file"; then
+      log_verbose "Updating: $src -> $dest_file"
       return 0
-      ;;
-    "$MODE_UPDATE")
-      if is_newer "$src" "$dest_file"; then
-        log_verbose "Updating: $src -> $dest_file"
-        return 0
-      fi
-      log_info "Skipped (not newer): $dest_file"
-      return 1
-      ;;
-    "$MODE_BACKUP")
-      if backup_file "$dest_file"; then
-        return 0
-      fi
-      return 2
-      ;;
-    *)
+    fi
+    log_info "Skipped (not newer): $dest_file"
+    return 1
+    ;;
+  "$MODE_BACKUP")
+    if backup_file "$dest_file"; then
       return 0
-      ;;
+    fi
+    return 2
+    ;;
+  *)
+    return 0
+    ;;
   esac
 }
 
@@ -617,20 +617,20 @@ copy_single_item() {
   assess_copy_preconditions "$src" "$dest_file"
   precondition_status=$?
   case $precondition_status in
-    0)
-      ;;
-    1)
-      # Skipped - not an error
-      return 0
-      ;;
-    2)
-      # Error in precondition
-      if [[ $FLAG_FAIL_FAST -eq 1 ]]; then
-        FLAG_ABORT_REQUESTED=1
-        log_verbose "Fail-fast requested after precondition failure: $src -> $dest_file"
-      fi
-      return 1
-      ;;
+  0)
+    ;;
+  1)
+    # Skipped - not an error
+    return 0
+    ;;
+  2)
+    # Error in precondition
+    if [[ $FLAG_FAIL_FAST -eq 1 ]]; then
+      FLAG_ABORT_REQUESTED=1
+      log_verbose "Fail-fast requested after precondition failure: $src -> $dest_file"
+    fi
+    return 1
+    ;;
   esac
 
   # Perform copy operation
@@ -749,16 +749,16 @@ copy_directory_tree() {
   check_destination_directory "$dest"
   dest_check_status=$?
   case $dest_check_status in
-    0)
-      ;;
-    2)
-      if ! create_destination_directory "$dest"; then
-        return 1
-      fi
-      ;;
-    *)
+  0)
+    ;;
+  2)
+    if ! create_destination_directory "$dest"; then
       return 1
-      ;;
+    fi
+    ;;
+  *)
+    return 1
+    ;;
   esac
 
   if [[ $FLAG_DRY_RUN -eq 1 ]]; then
@@ -856,16 +856,16 @@ main() {
   check_destination_directory "$dest_dir"
   dest_check_status=$?
   case $dest_check_status in
-    0)
-      ;;
-    2)
-      if ! create_destination_directory "$dest_dir"; then
-        return 1
-      fi
-      ;;
-    *)
+  0)
+    ;;
+  2)
+    if ! create_destination_directory "$dest_dir"; then
       return 1
-      ;;
+    fi
+    ;;
+  *)
+    return 1
+    ;;
   esac
 
   # Process each source
@@ -942,11 +942,11 @@ DEST_ARG=
 # @description Display help message (extracted from file header @help block)
 # @stdout Help text with usage and options
 show_help() {
-  sed -n '/^# @help<</,/^#<</p' "${BASH_SOURCE[0]}" \
-    | sed '1d;$d' \
-    | sed 's/^# //' \
-    | sed 's/^#$//' \
-    | sed "s/<SCRIPT_NAME>/$SCRIPT_NAME/g"
+  sed -n '/^# @help<</,/^#<</p' "${BASH_SOURCE[0]}" |
+    sed '1d;$d' |
+    sed 's/^# //' |
+    sed 's/^#$//' |
+    sed "s/<SCRIPT_NAME>/$SCRIPT_NAME/g"
   echo ""
   return 0
 }
@@ -956,12 +956,12 @@ show_help() {
 # @stdout Version and copyright information
 show_version() {
   local copyright_lines
-  copyright_lines=$(sed -n '1,/^$/p' "${BASH_SOURCE[0]}" \
-    | sed -n '/^# @license/,/^$/p' \
-    | sed '1d;$d' \
-    | sed 's/^# //' \
-    | sed 's/^#$//' \
-    | sed '/^$/d')
+  copyright_lines=$(sed -n '1,/^$/p' "${BASH_SOURCE[0]}" |
+    sed -n '/^# @license/,/^$/p' |
+    sed '1d;$d' |
+    sed 's/^# //' |
+    sed 's/^#$//' |
+    sed '/^$/d')
 
   printf '%s version %s\n\n%s\n\n' "$SCRIPT_NAME" "$VERSION" "$copyright_lines"
   return 0
@@ -981,75 +981,75 @@ parse_args() {
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      -h|--help)
-        show_help
-        return 1
-        ;;
-      -V|--version)
-        show_version
-        return 1
-        ;;
-      -n|--noclobber)
-        OPERATION_MODE=$MODE_SKIP
-        shift
-        ;;
-      -f|--force)
-        OPERATION_MODE=$MODE_OVERWRITE
-        shift
-        ;;
-      -u|--update)
-        OPERATION_MODE=$MODE_UPDATE
-        shift
-        ;;
-      -b|--backup)
-        OPERATION_MODE=$MODE_BACKUP
-        shift
-        ;;
-      -r|-R|--recursive)
-        FLAG_RECURSIVE=1
-        shift
-        ;;
-      -p|--parents)
-        FLAG_PARENTS=1
-        shift
-        ;;
-      -L|--dereference)
-        FLAG_DEREFERENCE=1
-        shift
-        ;;
-      -H|--hidden)
-        FLAG_INCLUDE_HIDDEN=1
-        shift
-        ;;
-      --dry-run)
-        FLAG_DRY_RUN=1
-        shift
-        ;;
-      --fail-fast)
-        FLAG_FAIL_FAST=1
-        shift
-        ;;
-      -v|--verbose)
-        logger_set_level "$LOGGER_LEVEL_VERBOSE"
-        shift
-        ;;
-      -q|--quiet)
-        logger_set_level "$LOGGER_LEVEL_ERROR"
-        shift
-        ;;
-      --)
-        shift
-        break
-        ;;
-      -*)
-        log_error "Unknown option: $1"
-        show_help >&2
-        return 1
-        ;;
-      *)
-        sources+=("$1")
-        shift
-        ;;
+    -h | --help)
+      show_help
+      return 1
+      ;;
+    -V | --version)
+      show_version
+      return 1
+      ;;
+    -n | --noclobber)
+      OPERATION_MODE=$MODE_SKIP
+      shift
+      ;;
+    -f | --force)
+      OPERATION_MODE=$MODE_OVERWRITE
+      shift
+      ;;
+    -u | --update)
+      OPERATION_MODE=$MODE_UPDATE
+      shift
+      ;;
+    -b | --backup)
+      OPERATION_MODE=$MODE_BACKUP
+      shift
+      ;;
+    -r | -R | --recursive)
+      FLAG_RECURSIVE=1
+      shift
+      ;;
+    -p | --parents)
+      FLAG_PARENTS=1
+      shift
+      ;;
+    -L | --dereference)
+      FLAG_DEREFERENCE=1
+      shift
+      ;;
+    -H | --hidden)
+      FLAG_INCLUDE_HIDDEN=1
+      shift
+      ;;
+    --dry-run)
+      FLAG_DRY_RUN=1
+      shift
+      ;;
+    --fail-fast)
+      FLAG_FAIL_FAST=1
+      shift
+      ;;
+    -v | --verbose)
+      logger_set_level "$LOGGER_LEVEL_VERBOSE"
+      shift
+      ;;
+    -q | --quiet)
+      logger_set_level "$LOGGER_LEVEL_ERROR"
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      log_error "Unknown option: $1"
+      show_help >&2
+      return 1
+      ;;
+    *)
+      sources+=("$1")
+      shift
+      ;;
     esac
   done
 


### PR DESCRIPTION
## Overview

**Summary**
テストとヘルパーのライブラリ参照を `COMMANDS_ROOT` 経由に統一する。

**Background / Motivation**
テストファイルとテストヘルパーが `$PROJECT_ROOT/.claude/commands/...` をハードコードしていたため、`.claude/commands` から `plugins/idd-framework/commands` へのディレクトリ移行にテスト側が追従できていなかった。

参照を `COMMANDS_ROOT="${COMMANDS_ROOT:-$PROJECT_ROOT/plugins/idd-framework/commands}"` 経由に統一することで、コマンド配置の変更をテスト側の 1 箇所で吸収できるようにする。あわせて環境変数 `COMMANDS_ROOT` による上書きを可能にし、配置が変わっても各テストファイルを個別に修正する必要をなくす。

同時に、`__tests__` 配下のテストが検出されないランナーの不具合を修正し、ShellSpec の実態に合わせた ShellCheck 設定の更新とシェルスクリプトのフォーマット整形を行う。

## Changes

### Core Changes

`runners/run-shellspec.sh` の spec 探索対象ディレクトリを `tests` から `__tests__` に修正し、`readonly SPEC_DIR_BASE="__tests__"` として定数化した。この修正がない場合、`__tests__` 配下のテストが検出されない。

`configs/shellcheckrc` の先頭のコピーライト行の崩れを修正した。disable リストを ShellSpec の実態に合わせて `SC1090,SC1091,SC2016,SC2034,SC2053,SC2317,SC2329` に拡張し、各ルールの無効化理由をコメントで明記した。

`scripts/xcp.sh` (270 行)、`plugins/idd-framework/commands/_libs/*.lib.sh` のリダイレクト空白・コメント空白・インデントを正規化した。ロジックの変更は含まない。

### Test Updates

テストおよびヘルパーのライブラリ参照を `COMMANDS_ROOT` 経由に変更した。本 PR の主目的にあたる。

- `plugins/idd-framework/commands/__tests__/unit/io-utils.unit.spec.sh`
- `plugins/idd-framework/commands/__tests__/unit/idd-issue-branch-*.unit.spec.sh` (7 件)
- `plugins/idd-framework/commands/__tests__/functional/idd-issue-branch-*.functional.spec.sh`
- `plugins/idd-framework/commands/__tests__/{integration,e2e}/idd-issue-push.*.spec.sh`
- `plugins/idd-framework/commands/__tests__/functional/filename-utils-slug.functional.spec.sh`
- `plugins/idd-framework/commands/__tests__/integration/filename-utils-translation.integration.spec.sh`

`__helpers/idd-issue-branch-functions.lib.sh` に branch command テスト用の session fixture 生成関数 `create_test_last_session` / `create_test_branch_session` を追加した (+56 行)。参照先も plugins 配下に変更した。

`scripts/__tests__/unit/xcp.spec.sh` のバックアップ数のカウントを `ls -1 "${dest_file}.bak."* | wc -l` から `find -maxdepth 1 -name ... -type f | wc -l` に変更した。glob が非マッチのときに誤カウントするのを回避する。

`__tests__/__helpers/*.lib.sh` および `run-tests.sh` のフォーマットを正規化した。ロジックの変更は含まない。

### Removed

なし。

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [x] Bug fix
- [x] Refactor
- [x] Test
- [ ] Documentation
- [x] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

Link any issues this PR closes or relates to:

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Breaking Change

なし。内部テスト構成のみの変更であり、外部インターフェースへの影響はない。

## Additional Notes

`pnpm run test:sh` を実行し、以下の結果を確認した。

```text
177 examples, 0 failures, 4 skips
```

4 件の skip は Windows/Git Bash で権限テストが安定しないため意図的にスキップしているもので、失敗ではない。対象は xcp の `validate_source` および `check_destination_directory` の非読み取り・非書き込みケース。

フォーマットと lint は以下をすべて実行し、終了コード 0 を確認した。

- `dprint check`
- `pnpm run lint:sh` (ShellCheck)
- `pnpm run check:sh` (shfmt)

ドキュメントの変更は本 PR に含まれないため、Documentation の項目は未チェックとした。

ドラフト生成時の情報:

- ブランチ: `refactor/unittest/refactor-test`
- ベース: `main`
- コミット数: 21
- 変更規模: 30 files, +479 / -406
